### PR TITLE
use InputImageType as OutputImageType

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Or using the pythonic API:
 
     import itk
     labels = itk.imread('path/to/labels.mha').astype(itk.US)
-    mask = itk.imread('path/to/mask.mha').astype(itk.UC)
+    mask = itk.imread('path/to/mask.mha').astype(itk.US)
     modified_labels = itk.dissolve_mask_image_filter(labels, mask_image=mask)
     itk.imwrite(modified_labels, 'path/to/modified_labels.mha')
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,27 @@ This is a module for the Insight Toolkit (ITK) that provides functionality to di
 The module includes a filter called DissolveMaskImageFilter.
 
 .. code-block:: python
+
+    import itk
+    labels = itk.imread('path/to/labels.mha').astype(itk.US)
+    mask = itk.imread('path/to/mask.mha').astype(itk.UC)
+
+    ImageType = type(labels)
+    MaskType = type(mask)
+
+    dissolve = itk.DissolveMaskImageFilter[ImageType, MaskType].New()
+    dissolve.SetInput(labels)
+    dissolve.SetMaskImage(mask)
+    dissolve.Update()
+    modified_labels = dissolve.GetOutput()
+
+    itk.imwrite(modified_labels, 'modified_labels2.mha')
+
+
+Or using the pythonic API:
+
+.. code-block:: python
+
     import itk
     labels = itk.imread('path/to/labels.mha').astype(itk.US)
     mask = itk.imread('path/to/mask.mha').astype(itk.UC)

--- a/include/itkDissolveMaskImageFilter.h
+++ b/include/itkDissolveMaskImageFilter.h
@@ -29,9 +29,9 @@ namespace itk
  * \note The pixels inside the mask are dissolved by assigning values
  * from neighboring region. The filter processes in an ordered fashion
  * from the mask boundary towards the inside.
- * 
+ *
  * \author Bryn Lloyd, IT'IS Foundation, Switzerland
- * 
+ *
  * \ingroup Dissolve
  */
 template <typename TInputImage, typename TMaskImage>
@@ -40,6 +40,7 @@ class ITK_TEMPLATE_EXPORT DissolveMaskImageFilter : public ImageToImageFilter<TI
 public:
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
+  itkStaticConstMacro(MaskImageDimension, unsigned int, TMaskImage::ImageDimension);
 
   static const unsigned int ImageDimension = InputImageDimension;
 
@@ -97,6 +98,7 @@ public:
   // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, MaskPixelType>));
+  itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, MaskImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   // End concept checking

--- a/include/itkDissolveMaskImageFilter.h
+++ b/include/itkDissolveMaskImageFilter.h
@@ -34,20 +34,19 @@ namespace itk
  * 
  * \ingroup Dissolve
  */
-template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
-class ITK_TEMPLATE_EXPORT DissolveMaskImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+template <typename TInputImage, typename TMaskImage>
+class ITK_TEMPLATE_EXPORT DissolveMaskImageFilter : public ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
 
   static const unsigned int ImageDimension = InputImageDimension;
 
   /** Convenient type aliases for simplifying declarations. */
   using InputImageType = TInputImage;
   using MaskImageType = TMaskImage;
-  using OutputImageType = TOutputImage;
+  using OutputImageType = TInputImage;
 
   /** Standard class type aliases. */
   using Self = DissolveMaskImageFilter;
@@ -97,9 +96,8 @@ public:
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
-  itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
+  itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, MaskPixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
-  itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   // End concept checking
 #endif

--- a/include/itkDissolveMaskImageFilter.hxx
+++ b/include/itkDissolveMaskImageFilter.hxx
@@ -32,16 +32,16 @@
 
 namespace itk
 {
-template <typename TInputImage, typename TMaskImage, typename TOutputImage>
-DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::DissolveMaskImageFilter()
+template <typename TInputImage, typename TMaskImage>
+DissolveMaskImageFilter<TInputImage, TMaskImage>::DissolveMaskImageFilter()
 {
   this->SetNumberOfRequiredInputs(2);
   m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
 }
 
-template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+template <typename TInputImage, typename TMaskImage>
 void
-DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::GenerateData()
+DissolveMaskImageFilter<TInputImage, TMaskImage>::GenerateData()
 {
   typename OutputImageType::Pointer     output = this->GetOutput();
   typename InputImageType::ConstPointer input = this->GetInput();
@@ -160,9 +160,9 @@ DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::GenerateData()
   }
 }
 
-template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+template <typename TInputImage, typename TMaskImage>
 std::vector<float>
-DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::GetNeighborDeltas(
+DissolveMaskImageFilter<TInputImage, TMaskImage>::GetNeighborDeltas(
   const std::vector<OffsetType> & offsets,
   const SpacingType &             spacing)
 {
@@ -183,9 +183,9 @@ DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::GetNeighborDelta
 /**
  * Standard "PrintSelf" method
  */
-template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+template <typename TInputImage, typename TMaskImage>
 void
-DissolveMaskImageFilter<TInputImage, TMaskImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
+DissolveMaskImageFilter<TInputImage, TMaskImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name="itk-dissolve",
-    version="0.9.1",
+    version="1.0.0",
     author="Bryn Lloyd",
     author_email="lloyd@itis.swiss",
     packages=["itk"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name="itk-dissolve",
-    version="1.0.0",
+    version="1.0.1",
     author="Bryn Lloyd",
     author_email="lloyd@itis.swiss",
     packages=["itk"],
@@ -41,6 +41,6 @@ setup(
     ],
     license="MIT",
     keywords="ITK InsightToolkit",
-    url=r"https://itk.org/",
+    url=r"https://github.com/dyollb/ITKDissolve",
     install_requires=[r"itk>=5.2.1.post1"],
 )

--- a/wrapping/itkDissolveMaskImageFilter.wrap
+++ b/wrapping/itkDissolveMaskImageFilter.wrap
@@ -1,5 +1,5 @@
 itk_wrap_class("itk::DissolveMaskImageFilter" POINTER)
-  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 2)
-  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 3)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT};UC" 2)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT};UC" 3)
 itk_end_wrap_class()
 

--- a/wrapping/itkDissolveMaskImageFilter.wrap
+++ b/wrapping/itkDissolveMaskImageFilter.wrap
@@ -1,7 +1,5 @@
 itk_wrap_class("itk::DissolveMaskImageFilter" POINTER)
-  foreach(t ${WRAP_ITK_SCALAR})
-    itk_wrap_image_filter_combinations("${t}" "${WRAP_ITK_INT}" "${t}" 2)
-    itk_wrap_image_filter_combinations("${t}" "${WRAP_ITK_INT}" "${t}" 3)
-  endforeach()
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 2)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 3)
 itk_end_wrap_class()
 

--- a/wrapping/itkDissolveMaskImageFilter.wrap
+++ b/wrapping/itkDissolveMaskImageFilter.wrap
@@ -1,5 +1,5 @@
 itk_wrap_class("itk::DissolveMaskImageFilter" POINTER)
-  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT};UC" 2)
-  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT};UC" 3)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 2)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}" 3)
 itk_end_wrap_class()
 


### PR DESCRIPTION
# use InputImageType as OutputImageType

this hopefully resolves issue with pythonic api

>>>Traceback (most recent call last):
  File "/Users/lloyd/Code/ITK_Module/ITKDissolve/../example_script.py", line 11, in <module>
    modified_labels = itk.dissolve_mask_image_filter(labels, mask_image=mask)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/support/helpers.py", line 173, in image_filter_wrapper
    return image_filter(*args, **kwargs)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/itkDissolveMaskImageFilterPython.py", line 2070, in dissolve_mask_image_filter
    instance = itk.DissolveMaskImageFilter.New(*args, **kwargs)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/support/template_class.py", line 734, in New
    return self[list(keys)[0]].New(*args, **kwargs)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/itkDissolveMaskImageFilterPython.py", line 2046, in New
    template_class.New(obj, *args, **kargs)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/support/template_class.py", line 800, in New
    itk.set_inputs(self, args, kargs)
  File "/Users/lloyd/Code/ITK_Module/.venv/lib/python3.9/site-packages/itk/support/extras.py", line 1252, in set_inputs
    attrib(itk.output(value))
TypeError: Expecting argument of type itkImageUS3 or itkImageSourceIUS3 